### PR TITLE
removed "force" parameter

### DIFF
--- a/lib/functions/unpackRemote.js
+++ b/lib/functions/unpackRemote.js
@@ -6,7 +6,7 @@ var constants = require('../constants.js');
  *
  * @param {getEventsCallback} callback
  */
-module.exports = function(force, callback) {
+module.exports = function(callback) {
     var local = constants.META_DIR + constants.META_LOCAL;
     var remote = constants.META_DIR + constants.META_REMOTE;
     //Calculate changes and ask for confimation, add -f flag to not do that


### PR DESCRIPTION
I removed the first parameter `force`.   This doesn't appear to be used and throws an error when using `gas clone`.   The clone was still successful but a TypeError was thrown: `callback` is not a function.

Removing the parameter `force` uses `callback` with its correct intentions.  