### PR TITLE
Add ability open auth url manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ $ npm i -g google-apps-script
 # Usage
 
 Authenticate the Drive API:   
-(Add '-f' to force reauthentication)
+(Add '-f' to force reauthentication, add '-s' to show the authentication url instead opening a webbrowser)
 
 ```
-$ gas auth [-f]
+$ gas auth [-f][-s]
 ```
 
 Create, delete or rename a project in your Google Drive:

--- a/bin/gas
+++ b/bin/gas
@@ -11,7 +11,8 @@ program
 program
     .command('auth')
     .option('-f, --force', 'Force reauthentication')
-    .description('authenticate the Drive API (add \'-f\' to force reauthentication)')
+    .option('-s, --show-url', 'Show the authentication url instead opening a webbrowser')
+    .description('authenticate the Drive API (add \'-f\' to force reauthentication, add \'-s\' to show the authentication url instead opening a webbrowser) ')
     .action(require(lib + '/auth'));
 
 program

--- a/lib/functions/authenticate.js
+++ b/lib/functions/authenticate.js
@@ -63,8 +63,9 @@ function storeToken(token) {
  *
  * @param {google.auth.OAuth2} oauth2Client - The OAuth2 client to get token for.
  * @returns {Promise} - A promise resolving an auth client
+ * @param {Object} [options] - Extra options.
  */
-function getNewToken(oauth2Client) {
+function getNewToken(oauth2Client, options) {
     return new Promise((resolve, reject) => {
         const server = http.createServer((req, res) => {
             const parsedUrl = url.parse(req.url, true);
@@ -102,7 +103,15 @@ function getNewToken(oauth2Client) {
             scope: constants.SCOPES,
         });
 
-        openWebpage(authUrl);
+        if(options.showUrl){
+            console.log('Please go to the following url in your browser:');
+            console.log('----------------------------------------------');
+            console.log(authUrl);
+            console.log('----------------------------------------------');
+        } else {
+            openWebpage(authUrl);
+        }
+
         console.log(`A webbrowser should have opened, to allow 'gas' to:`);
         console.log(`    'View and manage the files in your Google Drive'`);
         console.log(`    'Modify your Google Apps Script scripts' behavior'`);
@@ -134,7 +143,7 @@ function authenticate(options) {
         // Check if we have previously stored a token.
         fs.readFile(tokenFile, 'utf8', (err, token) => {
             if (err !== null || token === '') {
-                getNewToken(oauth2Client).then((newOauth2Client) => {
+                getNewToken(oauth2Client, options).then((newOauth2Client) => {
                     logAuth(newOauth2Client);
                     resolve(newOauth2Client);
                     return;
@@ -149,7 +158,7 @@ function authenticate(options) {
                 if (ttl < 10 * 1000 || options.refresh) {
                     oauth2Client.refreshAccessToken((err, token) => {
                         if (err) {
-                            getNewToken(oauth2Client).then((newOauth2Client) => {
+                            getNewToken(oauth2Client, options).then((newOauth2Client) => {
                                 resolve(newOauth2Client);
                                 return;
                             }, (err) => {


### PR DESCRIPTION
I have a problem. The 'open' module doesn't work with my environment.
I'm sure this feature is good. You are not need to solve troubles with old 'open' and Linux's xdg-open.

Just run and follow
```sh
> gas auth -s
Please go to the following url in your browser:
----------------------------------------------
https://accounts.google.com/o/oauth2/auth?access_type=offline...
----------------------------------------------
...
``` 

Best wishes